### PR TITLE
Add Snap Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,4 +43,3 @@ app.*.map.json
 /android/app/profile
 /android/app/release
 
-/assets/apikey.json

--- a/assets/apikey.json
+++ b/assets/apikey.json
@@ -1,0 +1,3 @@
+{
+    "apiKey": "YOUR_API_KEY_HERE"
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -582,5 +582,5 @@ packages:
     source: hosted
     version: "0.0.2"
 sdks:
-  dart: ">=2.19.0 <4.0.0"
+  dart: ">=2.19.0 <3.0.0"
   flutter: ">=3.7.0"

--- a/snap/gui/weather.desktop
+++ b/snap/gui/weather.desktop
@@ -1,0 +1,14 @@
+[Desktop Entry]
+Encoding=UTF-8
+
+Version=1.0
+Type=Application
+Name=Weather
+
+
+Terminal=false
+Exec=weather
+
+Keywords=Weather;Utilities;
+Comment=A flutter weather app
+Categories=Utilities;

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,69 @@
+name: weather
+title: Weather
+base: core22
+version: '0.1'
+summary: A beautiful weather app made with Flutter, and Yaru widgets.
+description: |
+  A beautiful weather app made with Flutter, and Yaru widgets.
+source-code: https://github.com/ubuntu-flutter-community/weather
+issues: https://github.com/ubuntu-flutter-community/weather/issues
+license: MPL-2.0
+
+
+compression: lzo
+grade: stable
+confinement: strict
+architectures: [amd64]
+
+parts:
+  flutter-git:
+    source: https://github.com/flutter/flutter.git
+    source-branch: stable
+    plugin: nil
+    override-build: |
+      mkdir -p $CRAFT_PART_INSTALL/usr/bin
+      mkdir -p $CRAFT_PART_INSTALL/usr/libexec
+      cp -r $CRAFT_PART_SRC $CRAFT_PART_INSTALL/usr/libexec/flutter
+      ln -s $CRAFT_PART_INSTALL/usr/libexec/flutter/bin/flutter $CRAFT_PART_INSTALL/usr/bin/flutter
+    build-packages:
+      - clang
+      - cmake
+      - curl
+      - ninja-build
+      - unzip
+      - xz-utils
+      - zip
+    prime:
+      - -*
+
+  weather:
+    plugin: nil
+    source: https://github.com/ubuntu-flutter-community/weather.git
+    after: [flutter-git]
+    
+    override-build: |
+      set -eux
+      flutter doctor
+      flutter pub get
+      flutter build linux --release -v
+      mkdir -p $CRAFT_PART_INSTALL/bin/
+      cp -r build/linux/*/release/bundle/* $CRAFT_PART_INSTALL/bin/ 
+
+slots:
+  weather-dbus: 
+   interface: dbus
+   bus: session
+   name: org.ubuntu_flutter_community.Weather
+
+apps:
+  weather:
+   command: bin/weather
+   desktop: snap/gui/weather.desktop
+   extensions: [gnome]
+   plugs:
+    - network
+    - x11
+    - wayland 
+    - desktop 
+    - desktop-legacy
+    - unity7 


### PR DESCRIPTION
Nice app, hope that snap support will help:
i) The `snapcraft.yaml` is not using the flutter plugin, it instead builds it from git. Choose to go that way, because it makes it easier to publish updates since you only need to `snapcraft pull weather` and `snapcraft` rather than building the whole flutter all over again.
ii) For the snap to build I had to remove the assets folder from gitignore, and also add it to github because its necessary to build the app, otherwise it fails 
iii) While I have added the network plug, I don't really know if it takes the data because I didn't create an API key, but it should work as expected.
vi) Created a `.desktop` file as well
I have added the snap in the pull request so you can test it.
P.S.: This is the second try, I messed up with the commits in the previous one, still learning.